### PR TITLE
bugfix: [#2] Add correct z-index to socials container in the footer.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -874,6 +874,7 @@ footer .logo-container .logo{
   display: flex;
   flex-direction: column;
   gap: 1.8rem;
+  z-index: 0;
 }
 footer .footer-socials ul {
   display: flex;


### PR DESCRIPTION
Fix issue #2: In mobile view, when the side panel is opened, the social media icons stay in front of the menu.